### PR TITLE
Compare keyitems with keys

### DIFF
--- a/include/AKeyable.h
+++ b/include/AKeyable.h
@@ -29,7 +29,8 @@ public:
 	/**
 	 * @brief Define comparison operators.
 	 */
-	auto operator <=>( const AKeyable& ) const = default;
+	auto operator<=>( const AKeyable& ) const = default;
+	auto operator<=>( const key_type& aKey ) const{ return mKey <=> aKey; }
 
 private:
 	//! Key of the class.

--- a/include/frontend/CSetMenuSelector.h
+++ b/include/frontend/CSetMenuSelector.h
@@ -95,7 +95,13 @@ CSetMenuSelector<T>::operations CSetMenuSelector<T>::GetOperations() const noexc
 		[]( const set_type& ){ return false; },
 		[]( const set_type& aSet ){ for( const auto& element : aSet ) std::cout << element.GetDescription(); return true; },
 		[&]( set_type& aSet ){ aSet.emplace( AskInput<T>( "Item:" ) ); return true; },
-		[&]( set_type& aSet ){ aSet.erase( T{ AskInput<types::AKeyable::key_type>( "Item:" ) } ); return true; },
+		[&]( set_type& aSet )
+			{
+				const auto found = aSet.find( AskInput<types::AKeyable::key_type>( "Item:" ) );
+				if( found != aSet.cend() )
+					aSet.erase( found );
+				return true;
+			},
 		[&]( set_type& aSet )
 			{
 				auto inputElement = AskInput<T>( "Item:" );

--- a/include/frontend/CSetMenuSelector.h
+++ b/include/frontend/CSetMenuSelector.h
@@ -25,9 +25,10 @@ namespace frontend
  * @brief Class to manage the key sets class menu options.
  */
 template <typename T> requires std::derived_from<T, IDescriptable>
-class CSetMenuSelector : public IMenuSelector<std::set<T>&>
+class CSetMenuSelector : public IMenuSelector<std::set<T,types::AKeyable::SKeyCompare>&>
 {
-	using operations = IMenuSelector<std::set<T>&>::operations;
+	using operations = IMenuSelector<std::set<T,types::AKeyable::SKeyCompare>&>::operations;
+	using set_type = std::set<T,types::AKeyable::SKeyCompare>;
 
 	//! Retrieves the introductory text.
 	constexpr std::string GetIntro() const noexcept override;
@@ -91,11 +92,11 @@ template <typename T> requires std::derived_from<T, IDescriptable>
 CSetMenuSelector<T>::operations CSetMenuSelector<T>::GetOperations() const noexcept
 {
 	return {
-		[]( const std::set<T>& ){ return false; },
-		[]( const std::set<T>& aSet ){ for( const auto& element : aSet ) std::cout << element.GetDescription(); return true; },
-		[&]( std::set<T>& aSet ){ aSet.emplace( AskInput<T>( "Item:" ) ); return true; },
-		[&]( std::set<T>& aSet ){ aSet.erase( T{ AskInput<types::AKeyable::key_type>( "Item:" ) } ); return true; },
-		[&]( std::set<T>& aSet )
+		[]( const set_type& ){ return false; },
+		[]( const set_type& aSet ){ for( const auto& element : aSet ) std::cout << element.GetDescription(); return true; },
+		[&]( set_type& aSet ){ aSet.emplace( AskInput<T>( "Item:" ) ); return true; },
+		[&]( set_type& aSet ){ aSet.erase( T{ AskInput<types::AKeyable::key_type>( "Item:" ) } ); return true; },
+		[&]( set_type& aSet )
 			{
 				auto inputElement = AskInput<T>( "Item:" );
 				if( aSet.extract( inputElement ) )

--- a/include/types/AKeyable.h
+++ b/include/types/AKeyable.h
@@ -5,10 +5,35 @@
 /**
  * @brief Types defined for \ref AKeyable.
 */
-namespace ypp_sm::types::AKeyable
+namespace ypp_sm
+{
+
+class AKeyable;
+
+namespace types::AKeyable
 {
 
 //! Type for the internal key type.
 using key_type = std::string;
 
-} // ypp_sm::types::AKeyable namespace
+/**
+ * @brief Define key comparison operators.
+ */
+struct SKeyCompare
+{
+	using is_transparent = void;
+	/**
+	 * @brief Define comparisons for the class.
+	 * @{
+	 */
+	bool operator()( const ypp_sm::AKeyable& aLHS, const ypp_sm::AKeyable& aRHS ) const;
+	bool operator()( const ypp_sm::AKeyable& aLHS, const key_type& aRHS ) const;
+	bool operator()( const key_type& aLHS, const ypp_sm::AKeyable& aRHS ) const;
+	/**
+	 * @}
+	 */
+};
+
+} // ypp_sm
+
+} // types::AKeyable namespace

--- a/include/types/CKeySets.h
+++ b/include/types/CKeySets.h
@@ -21,7 +21,7 @@ namespace types::CKeySets
 template<typename T> concept is_keyable = std::derived_from<T, ypp_sm::AKeyable>;
 
 //! Type for the sets classified by some key.
-template <is_keyable T> using key_sets = std::map<AKeyable::key_type, std::set<T>>;
+template <is_keyable T> using key_sets = std::map<AKeyable::key_type, std::set<T,AKeyable::SKeyCompare>>;
 
 } // types::CKeySets namespace
 

--- a/include/types/CRecipe.h
+++ b/include/types/CRecipe.h
@@ -2,6 +2,8 @@
 
 #include <set>
 
+#include "types/AKeyable.h"
+
 /**
  * @brief Types defined for \ref CRecipe.
 */
@@ -16,7 +18,7 @@ namespace types::CRecipe
 //! Type for a number of items.
 using count = unsigned int;
 //! Type for a set of recipe items.
-using items = std::set<ypp_sm::CKeyItem<count>>;
+using items = std::set<ypp_sm::CKeyItem<count>,AKeyable::SKeyCompare>;
 
 } // types::CRecipe namespace
 

--- a/src/AKeyable.cpp
+++ b/src/AKeyable.cpp
@@ -15,4 +15,19 @@ std::string_view AKeyable::GetKey() const noexcept
 	return mKey;
 }
 
+bool types::AKeyable::SKeyCompare::operator()( const ypp_sm::AKeyable& aLHS, const ypp_sm::AKeyable& aRHS ) const
+{
+	return aLHS < aRHS;
+}
+
+bool types::AKeyable::SKeyCompare::operator()( const ypp_sm::AKeyable& aLHS, const key_type& aRHS ) const
+{
+	return aLHS < aRHS;
+}
+
+bool types::AKeyable::SKeyCompare::operator()( const key_type& aLHS, const ypp_sm::AKeyable& aRHS ) const
+{
+	return aLHS < aRHS;
+}
+
 } // ypp_sm namespace


### PR DESCRIPTION
Avoid creating full keyable object when only the key part is needed when comparing